### PR TITLE
Change report functionality on reviews

### DIFF
--- a/client/components/Reviews/ReportedReview.jsx
+++ b/client/components/Reviews/ReportedReview.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export const ReportedReview = props => (
-  <div className="reported">
-    <h1>Your report has been submitted</h1>
-  </div>
-);

--- a/client/components/Reviews/ReviewItem.jsx
+++ b/client/components/Reviews/ReviewItem.jsx
@@ -5,7 +5,6 @@ import {
   incrementHelpfulness,
   reportReview
 } from '../../greenfieldAPI/reviews';
-import { ReportedReview } from './ReportedReview';
 import ThumbnailGallery from '../Questions/ThumbnailGallery';
 
 const ReviewItem = ({
@@ -50,73 +49,68 @@ const ReviewItem = ({
     });
   };
 
-  if (isReported) {
-    return <ReportedReview />;
-  } else {
-    let responseContainer = null;
-    if (response) {
-      responseContainer = (
-        <div className="review-response">
-          <h2>Response:</h2>
-          <br />
-          {response}
-        </div>
-      );
-    }
-    return (
-      <div className="review-item">
-        <div className="review-item-top">
-          <Stars stars={rating} />
-          <p>
-            {reviewer_name}, {displayDate.toLocaleString('en-US')}
-          </p>
-        </div>
-        <p className="summary">{summary}</p>
-        <ThumbnailGallery imageURLs={photoURLs} />
-        <p className="review-body">
-          {expandedReviews.includes(review_id) ? body : body.slice(0, 250)}
-          {body.length > 250 && !expandedReviews.includes(review_id) ? (
-            <>
-              &nbsp;
-              <span
-                className="underline-clickable show-more"
-                onClick={() =>
-                  setExpandedReviews([...expandedReviews, review_id])
-                }
-              >
-                ...show more
-              </span>
-            </>
-          ) : null}
-        </p>
-        {recommend === 1 ? (
-          <p>
-            <i className="fa fa-check"></i> I recommend this product
-          </p>
-        ) : null}
-        {responseContainer}
-        <div className="review-item-bottom">
-          Helpful?&nbsp;&nbsp;
-          <span onClick={() => handleHelpful(review_id)}>
-            <span
-              className={
-                helpfulReviews.includes(review_id) ? '' : 'underline-clickable'
-              }
-            >
-              Yes
-            </span>
-          </span>
-          &nbsp; ({helpfulness}) | &nbsp;
-          <span
-            className="underline-clickable"
-            onClick={() => handleReport(review_id)}
-          >
-            Report
-          </span>
-        </div>
+  let responseContainer = null;
+  if (response) {
+    responseContainer = (
+      <div className="review-response">
+        <h2>Response:</h2>
+        <br />
+        {response}
       </div>
     );
   }
+  return (
+    <div className="review-item">
+      <div className="review-item-top">
+        <Stars stars={rating} />
+        <p>
+          {reviewer_name}, {displayDate.toLocaleString('en-US')}
+        </p>
+      </div>
+      <p className="summary">{summary}</p>
+      <ThumbnailGallery imageURLs={photoURLs} />
+      <p className="review-body">
+        {expandedReviews.includes(review_id) ? body : body.slice(0, 250)}
+        {body.length > 250 && !expandedReviews.includes(review_id) ? (
+          <>
+            &nbsp;
+            <span
+              className="underline-clickable show-more"
+              onClick={() =>
+                setExpandedReviews([...expandedReviews, review_id])
+              }
+            >
+              ...show more
+            </span>
+          </>
+        ) : null}
+      </p>
+      {recommend === 1 ? (
+        <p>
+          <i className="fa fa-check"></i> I recommend this product
+        </p>
+      ) : null}
+      {responseContainer}
+      <div className="review-item-bottom">
+        Helpful?&nbsp;&nbsp;
+        <span onClick={() => handleHelpful(review_id)}>
+          <span
+            className={
+              helpfulReviews.includes(review_id) ? '' : 'underline-clickable'
+            }
+          >
+            Yes
+          </span>
+        </span>
+        &nbsp; ({helpfulness}) | &nbsp;
+        <span
+          className={isReported ? '' : 'underline-clickable'}
+          onClick={() => handleReport(review_id)}
+        >
+          {isReported ? 'Reported' : 'Report'}
+        </span>
+      </div>
+    </div>
+  );
 };
-
 export default ReviewItem;


### PR DESCRIPTION
Previously when reporting a review, the whole review would be removed immediately and replaced with text indicating that the review was reported. Now the review remains but the "Report" button
changes to "Reported" without underlining or changing your cursor to a pointer, and the review is then removed on page re-render.